### PR TITLE
Fixed dependency error with importlib-metadata on Python 3.8

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -42,8 +42,8 @@ PyYAML>=5.3.1; python_version > '3.4'
 # Tox
 tox>=2.5.0
 # tox 3.17 requires six>=1.14.0 - covered in test-requirements.txt
-# tox 3.14 requires importlib-metadata<1,>=0.12 on py<=3.8
-importlib-metadata<1,>=0.12; python_version <= '3.8'
+# tox 3.14 requires importlib-metadata<1,>=0.12 on py<3.8
+importlib-metadata<1,>=0.12; python_version < '3.8'
 
 # Sphinx (no imports, invoked via sphinx-build script):
 # Keep in sync with rtd-requirements.txt

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed a dependency error that caused importlib-metadata to be installed on
+  Python 3.8, while it is included in the Python base.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -156,8 +156,8 @@ PyYAML==5.3.1; python_version >= '3.5'
 # Tox
 tox==2.5.0
 # tox 3.17 requires six>=1.14.0
-# tox 3.14 requires importlib-metadata<1,>=0.12 on py<=3.8
-importlib-metadata==0.12; python_version <= '3.8'
+# tox 3.14 requires importlib-metadata<1,>=0.12 on py<3.8
+importlib-metadata==0.12; python_version < '3.8'
 
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx==1.7.6


### PR DESCRIPTION
See commit message.