### PR TITLE
Added support for Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "::set-output name=matrix::{ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
-            \"python-version\": [ \"2.7\", \"3.4\", \"3.5\", \"3.6\", \"3.7\", \"3.8\", \"3.9\" ], \
+            \"python-version\": [ \"2.7\", \"3.4\", \"3.5\", \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"exclude\": [ \
               { \
@@ -79,7 +79,7 @@ jobs:
         else \
           echo "::set-output name=matrix::{ \
             \"os\": [ \"ubuntu-latest\" ], \
-            \"python-version\": [ \"2.7\", \"3.9\" ], \
+            \"python-version\": [ \"2.7\", \"3.10\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"include\": [ \
               { \
@@ -99,7 +99,7 @@ jobs:
               }, \
               { \
                 \"os\": \"macos-latest\", \
-                \"python-version\": \"3.9\", \
+                \"python-version\": \"3.10\", \
                 \"package_level\": \"latest\" \
               }, \
               { \
@@ -109,7 +109,7 @@ jobs:
               }, \
               { \
                 \"os\": \"windows-latest\", \
-                \"python-version\": \"3.9\", \
+                \"python-version\": \"3.10\", \
                 \"package_level\": \"latest\" \
               } \
             ] \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -50,12 +50,16 @@ importlib-metadata<1,>=0.12; python_version < '3.8'
 
 # Sphinx 2.0.0 removed support for Python 2.7 and 3.4
 # Sphinx 4.0.0 breaks autodocsumm and needs to be excluded
+# Sphinx <4.2.0 fails on Python 3.10 because it tries to import non-existing
+#   types.Union. This also drives docutils>=0.14.
 # Sphinx pins docutils to <0.18 (some versions even to <0.17) but the package
 #   version resolver in the pip version used on py27 ignores package dependencies
 Sphinx>=1.7.6,<2.0.0; python_version <= '3.4'
-Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5'
+Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5' and python_version <= '3.9'
+Sphinx>=4.2.0; python_version >= '3.10'
 docutils>=0.13.1,<0.17; python_version == '2.7'
-docutils>=0.13.1; python_version >= '3.4'
+docutils>=0.13.1; python_version >= '3.4' and python_version <= '3.9'
+docutils>=0.14; python_version >= '3.10'
 sphinx-git>=10.1.1
 GitPython>=2.1.1
 sphinxcontrib-fulltoc>=1.2.0
@@ -64,9 +68,14 @@ sphinxcontrib-websupport>=1.1.2
 Pygments>=2.1.3; python_version == '2.7'
 Pygments>=2.1.3,<2.4.0; python_version == '3.4'
 Pygments>=2.1.3; python_version >= '3.5'
+sphinx-rtd-theme>=0.5.0
+# autodocsumm before 0.2.5 fails on Python 3.10 with TypeError
 autodocsumm>=0.1.13,<0.2.0; python_version == '2.7'
 autodocsumm>=0.1.13,<0.2.0; python_version == '3.4'
-autodocsumm>=0.1.13; python_version >= '3.5'
+autodocsumm>=0.1.13; python_version >= '3.5' and python_version <= '3.9'
+autodocsumm>=0.2.5; python_version >= '3.10'
+# Babel 2.7.0 fixes an ImportError for MutableMapping which starts failing on Python 3.10
+Babel>=2.7.0
 
 # PyLint (no imports, invoked via pylint script)
 # Pylint requires astroid

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,6 +25,9 @@ Released: not yet
 
 **Enhancements:**
 
+* Support for Python 3.10: Added Python 3.10 in GitHub Actions tests, and in
+  package metadata.
+
 **Cleanup:**
 
 **Known issues:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -67,15 +67,16 @@
 # For the base packages, we use the versions from Ubuntu 18.04 as a general
 # minimum, and then increase it to the first version that introduced support
 # for a particular Python version.
-# On pypy3 (py36), pip 18.0 is needed to support constraints like cffi!=1.11.3,>=1.8
+# pip 18.0 is needed on pypy3 (py36) to support constraints like cffi!=1.11.3,>=1.8.
 # pip 10.0.0 introduced the --exclude-editable option.
+# Pip 20.2 introduced a new resolver whose backtracking had issues that were resolved only in 21.2.2.
+# pip>=21.0 is needed for the cryptography package on Windows on GitHub Actions.
 pip==10.0.1; python_version <= '3.5'
-pip==18.0; python_version == '3.6'
-pip==18.1; python_version == '3.7'
-pip==19.3.1; python_version >= '3.8'
+pip==21.2.2; python_version >= '3.6'
 setuptools==39.0.1; python_version <= '3.6'
 setuptools==40.6.0; python_version == '3.7'
-setuptools==41.5.0; python_version >= '3.8'
+setuptools==41.5.0; python_version >= '3.8' and python_version <= '3.9'
+setuptools==49.0.0; python_version >= '3.10'
 wheel==0.30.0; python_version <= '3.6'
 wheel==0.32.0; python_version == '3.7'
 wheel==0.33.5; python_version >= '3.8'
@@ -99,7 +100,8 @@ wheel==0.33.5; python_version >= '3.8'
 # pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
 pytest==4.3.1; python_version <= '3.6'
-pytest==4.4.0; python_version >= '3.7'
+pytest==4.4.0; python_version >= '3.7' and python_version <= '3.9'
+pytest==6.2.5; python_version >= '3.10'
 testfixtures==6.9.0
 decorator==4.0.11
 mock==2.0.0
@@ -135,6 +137,16 @@ pathlib2==2.3.3; python_version < '3.4' and sys_platform != 'win32'
 
 # Direct dependencies for development (must be consistent with dev-requirements.txt)
 
+# FormEncode is used for xml comparisons in unit test
+FormEncode==1.3.1; python_version <= '3.9'
+FormEncode==2.0.0; python_version >= '3.10'
+
+# Lxml
+lxml==4.6.2; python_version == '2.7'
+lxml==4.2.4; python_version == '3.4'
+lxml==4.6.2; python_version >= '3.5' and python_version <= '3.9'
+lxml==4.6.4; python_version >= '3.10'
+
 # Coverage reporting (no imports, invoked via coveralls script):
 # We exclude Python 3.4 from coverage testing and reporting.
 coverage==5.0; python_version == '2.7' or python_version >= '3.5'
@@ -157,18 +169,23 @@ PyYAML==5.3.1; python_version >= '3.5'
 tox==2.5.0
 # tox 3.17 requires six>=1.14.0
 # tox 3.14 requires importlib-metadata<1,>=0.12 on py<3.8
-importlib-metadata==0.12; python_version < '3.8'
+importlib-metadata==0.12; python_version <= '3.7'
 
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx==1.7.6; python_version <= '3.4'
-Sphinx==3.5.4; python_version >= '3.5'
-docutils==0.13.1
+Sphinx==3.5.4; python_version >= '3.5' and python_version <= '3.9'
+Sphinx==4.2.0; python_version >= '3.10'
+docutils==0.13.1; python_version == '2.7'
+docutils==0.13.1; python_version >= '3.4' and python_version <= '3.9'
+docutils==0.14; python_version >= '3.10'
 sphinx-git==10.1.1
 GitPython==2.1.1
 sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-websupport==1.1.2
 Pygments==2.1.3
-autodocsumm==0.1.13
+sphinx-rtd-theme==0.5.0
+autodocsumm==0.1.13; python_version <= '3.9'
+autodocsumm==0.2.5; python_version >= '3.10'
 
 # PyLint (no imports, invoked via pylint script) - does not support py3:
 pylint==1.6.4; python_version == '2.7'
@@ -226,7 +243,8 @@ pyinstrument-cext==0.2.0  # from pyinstrument
 # Indirect dependencies with special constraints:
 
 # pytz (used by TBD)
-pytz==2016.10
+pytz==2016.10; python_version <= '3.9'
+pytz==2019.1; python_version >= '3.10'
 
 # colorama (used by TBD)
 # colorama 0.4.0 removed support for Python 3.4
@@ -265,7 +283,7 @@ appnope==0.1.0
 args==0.1.0
 atomicwrites==1.2.1; python_version == '2.7'
 attrs==18.2.0
-Babel==2.3.4
+Babel==2.7.0
 backports-abc==0.5
 backports.functools-lru-cache==1.5; python_version < '3.3'
 backports.shutil-get-terminal-size==1.0.0
@@ -294,11 +312,12 @@ idna==2.5
 imagesize==0.7.1
 importlib-metadata==0.12; python_version <= '3.7'
 isort==4.2.15
-Jinja2==2.8
-jsonschema==2.5.1
+Jinja2==2.8; python_version <= '3.9'
+Jinja2==2.10.2; python_version >= '3.10'
+jsonschema==2.6.0
 keyring==17.0.0; python_version >= '3.4'
 linecache2==1.0.0
-MarkupSafe==0.23
+MarkupSafe==1.1.0
 mistune==0.8.1
 more-itertools==5.0.0
 ordereddict==1.1
@@ -316,7 +335,8 @@ python-dateutil==2.6.0; python_version >= '3.4'
 pyzmq==16.0.4; python_version >= '3.4'
 qtconsole==4.2.1
 requests==2.20.1
-requests-toolbelt==0.7.0
+requests-mock==1.6.0
+requests-toolbelt==0.8.0
 rfc3986==1.3.0; python_version >= '3.4'
 scandir==1.9.0; python_version == '2.7'
 sh==1.12.14

--- a/setup.py
+++ b/setup.py
@@ -239,6 +239,8 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,12 +13,17 @@
 # pytest 5.0.0 has removed support for Python < 3.5
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
 pytest>=4.3.1,<5.0.0; python_version < '3.5'
-pytest>=4.3.1; python_version >= '3.5' and python_version <= '3.6'
-pytest>=4.4.0; python_version >= '3.7'
+pytest>=4.3.1,!=6.0; python_version >= '3.5' and python_version <= '3.6'
+pytest>=4.4.0,!=6.0; python_version >= '3.7' and python_version <= '3.9'
+pytest>=6.2.5; python_version >= '3.10'
 testfixtures>=6.9.0
 decorator>=4.0.11
 mock>=2.0.0
 yagot>=0.5.0
+importlib-metadata<1,>=0.12; python_version <= '3.7'
+# pytz before 2019.1 fails on Python 3.10 because it uses collections.Mapping
+pytz>=2016.10; python_version <= '3.9'
+pytz>=2019.1; python_version >= '3.10'
 
 
 # Install test direct dependencies:
@@ -49,5 +54,21 @@ six>=1.14.0
 # pathlib2 (used by virtualenv on py<3.4 on non-Windows)
 pathlib2<3,>=2.3.3; python_version < '3.4' and sys_platform != 'win32'
 
+backports.statistics>=0.1.0; python_version == '2.7'
+# FormEncode is used for xml comparisons in unit test
+# FormEncode 1.3.1 has no python_requires and fails install on Python 3.10 due to incorrect version checking
+FormEncode>=1.3.1; python_version <= '3.9'
+FormEncode>=2.0.0; python_version >= '3.10'
+
+# Lxml
+# lxml 4.4.0 removed Python 3.4 support
+# lxml 4.4.3 added Python 3.8 support and exposed it correctly
+# lxml 4.6.1 addressed safety issue 38892
+# lxml 4.6.2 addressed safety issue 39194
+# lxml 4.6.3 addressed safety issue 40072
+lxml>=4.6.2; python_version == '2.7'
+lxml>=4.2.4,<4.4.0; python_version == '3.4'
+lxml>=4.6.2; python_version >= '3.5' and python_version <= '3.9'
+lxml>=4.6.4; python_version >= '3.10'
 
 # Additional indirect dependencies are not specified in this file.

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ envlist =
     py36
     py37
     py38
+    py39
+    py310
     win64_py27_32
     win64_py27_64
     win64_py34_32
@@ -26,10 +28,16 @@ envlist =
     win64_py37_64
     win64_py38_32
     win64_py38_64
+    win64_py39_32
+    win64_py39_64
+    win64_py310_32
+    win64_py310_64
     cygwin64_py27
     cygwin64_py36
     cygwin64_py37
     cygwin64_py38
+    cygwin64_py39
+    cygwin64_py310
 
 skip_missing_interpreters = false
 
@@ -101,6 +109,14 @@ basepython = python3.7
 platform = linux2|darwin
 basepython = python3.8
 
+[testenv:py39]
+platform = linux2|darwin
+basepython = python3.9
+
+[testenv:py310]
+platform = linux2|darwin
+basepython = python3.10
+
 # Note: The basepython file paths for the win64* tox environments may need to
 #       be customized.
 
@@ -152,6 +168,22 @@ basepython = C:\Python38\python.exe
 platform = win32
 basepython = C:\Python38-x64\python.exe
 
+[testenv:win64_py39_32]
+platform = win32
+basepython = C:\Python39\python.exe
+
+[testenv:win64_py39_64]
+platform = win32
+basepython = C:\Python39-x64\python.exe
+
+[testenv:win64_py310_32]
+platform = win32
+basepython = C:\Python310\python.exe
+
+[testenv:win64_py310_64]
+platform = win32
+basepython = C:\Python310-x64\python.exe
+
 # Note: The 32-bit versions of CygWin do not work:
 # - Python 2.7 with cygwin 32-bit fails with "virtualenv is not compatible with
 #   this system or executable".
@@ -172,3 +204,11 @@ basepython = python3.7
 [testenv:cygwin64_py38]
 platform = cygwin
 basepython = python3.8
+
+[testenv:cygwin64_py39]
+platform = cygwin
+basepython = python3.9
+
+[testenv:cygwin64_py310]
+platform = cygwin
+basepython = python3.10


### PR DESCRIPTION
Details:

* Python 3.10 enablement:
  * Added 3.10 in Actions test for complete run.
  * Switched from 3.9 to 3.10 in Actions test for partial (standard) run.
  * Added 3.10 in package metadata.
  * Added 3.9 and 3.10 in tox.ini.

* Pip package:
  Pip 20.2 introduced a new resolver whose backtracking in case of requirements
  conflicts had issues that were resolved only in 21.2.2. To address that, the
  minimum version for Pip was increased from 21.1 to 21.2.2 for Python >= 3.6.

* FormEncode package:
  Increased the minimum version of FormEncode from 1.3.1 to 2.0.0 for Python
  3.10 and higher, to circumvent an install error caused by FormEncode not
  using python_requires and instead comparing the Python version in its
  setup.py. In 1.3.1, that version check was incorrect because it compares
  just the version strings, so '3.10' is evaluated as being below '3.2' it
  compares to. Fixed that by increasing

* lxml package:
  Increased minimum version of lxml from 4.6.2 to 4.6.4 on Python 3.10 to
  address an installation error.

* pytest package:
  Increased pytest minimum version to 6.2.5 on Python 3.10.
  Removed pinning of pytest to <6.0.0 on Python 3.5 and higher and replaced it
  with excluding 6.0.* because the issue had been fixed in 6.1.0.

* Sphinx package:
  Increased minimum version to 4.2.0 on Python 3.10, because below that
  sphinx/util/typing.py tries to import non-existing types.Union.

* docutils package:
  The increase of Sphinx to >=4.2.0 drives an increase of docutils to >=0.14 on
  Python 3.10.

* Babel package:
  Babel 2.7.0 fixes an ImportError for MutableMapping which starts failing on
  Python 3.10. Increases minimum version from 2.3.4 to 2.7.0.

* autodocsumm package:
  autodocsumm before 0.2.5 fails on Python 3.10 with TypeError. Fixed that by
  increasing its minimum version from 0.1.13 to 0.2.5 on Python 3.10 and higher.

* pytz package:
  pytz before 2019.1 fails on Python 3.10 with ImportError on
  collections.Mapping. Fixed that by increasing its minimum version from 2016.10
  to 2019.1 for Python 3.10.

* Jinja2 package:
  Jinja2 before 2.10.2 fails on Python 3.10 with ImportError on
  collections.Mapping. Fixed that by increasing its minimum version from 2.8
  to 2.10.2 on Python 3.10 and higher.

* MarkupSafe package:
  MarkupSafe before 1.1.0 fails on Python 3.10 with ImportError on
  collections.Mapping. Fixed that by increasing its minimum version from 0.23
  to 1.1.0 on Python 3.10 and higher.

* setuptools package:
  setuptools before 49.0.0 compares Python versions in requirements based on
  strings and thus ignores certain requirements on Python 3.10, leading to
  missing packages in the installtest test2. Fixed that by increasing
  the minimum version of setuptools from 41.5.0 to 49.0.0 on Python
  3.10 and higher.

* pywin32 package:
  To circumvent https://github.com/pypa/pip/issues/10701, the minimum for
  pywin32 was excluded on Python 3.10.

Signed-off-by: Andreas Maier <andreas.r.maier@gmx.de>